### PR TITLE
Escape toggles mouse and clicking does not unlock pointer

### DIFF
--- a/p5/player.js
+++ b/p5/player.js
@@ -32,6 +32,7 @@ class Player extends RoverCam {
 			if (keyIsDown(69)) this.moveZ(0.05); // e
 		}
 		if (keyPressed(ESCAPE)) this.pointerLock = false;
+		// unlock pointer if ESC is pressed
     }
     
     update() {

--- a/p5/player.js
+++ b/p5/player.js
@@ -31,6 +31,7 @@ class Player extends RoverCam {
 			if (keyIsDown(83) || keyIsDown(DOWN_ARROW)) this.moveX(-this.speed); // s
 			if (keyIsDown(69)) this.moveZ(0.05); // e
 		}
+		if (keyPressed(ESCAPE)) this.pointerLock = false;
     }
     
     update() {

--- a/p5/sketch.js
+++ b/p5/sketch.js
@@ -167,7 +167,7 @@ function mouseClicked() {
 	if (!player.pointerLock) {
 		player.pointerLock = true;
 		requestPointerLock();
-	} else {
-		console.log("click interaction on else mouseClicked()");
-	}
+	} /*else {
+		//click interaction
+	}*/
 }

--- a/p5/sketch.js
+++ b/p5/sketch.js
@@ -163,12 +163,11 @@ if (startVisible) {
 	// 	pop();
 	// }
 
-	function mouseClicked() {
+function mouseClicked() {
 	if (!player.pointerLock) {
 		player.pointerLock = true;
 		requestPointerLock();
 	} else {
-		exitPointerLock();
-		player.pointerLock = false;
+		console.log("click interaction on else mouseClicked()");
 	}
 }


### PR DESCRIPTION
Changed controller() in player.js to have an extra way of checking if ESC is pressed (just in case) for toggling pointer control, also removed else condition in bottom of sketch.js where it would toggle pointerlock on clicking